### PR TITLE
WIP: Add support for Composite to the branch containing Abstract Zero support

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -7,7 +7,7 @@ using ArrayLayouts: MemoryLayout, AbstractColumnMajor
 import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback
 import ZygoteRules: literal_getproperty, diff2generic
 
-using ChainRules: ChainRules, rrule, unthunk, AbstractZero, Zero, DoesNotExist
+using ChainRules: ChainRules, rrule, unthunk, AbstractZero, Zero, DoesNotExist, Composite
 using IRTools
 using MacroTools, Requires
 using MacroTools: @forward

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -5,7 +5,7 @@ using LinearAlgebra: copytri!, AbstractTriangular
 using ArrayLayouts: MemoryLayout, AbstractColumnMajor
 
 import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback, literal_getproperty
-using ZygoteRules: differential2legacy, legacy2differential, legacytype_warn, gradtuple1
+using ZygoteRules: differential2legacy, legacy2differential, legacytype_warn, diffgradtuple1
 
 using ChainRules: ChainRules, rrule, unthunk, AbstractZero, Zero, DoesNotExist, Composite
 using IRTools

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -9,7 +9,7 @@ import ZygoteRules: literal_getproperty, differential2legacy, legacy2differentia
 import ZygoteRules: legacytype_warn
 import ZygoteRules
 
-using ChainRules: ChainRules, rrule, unthunk, AbstractZero, Zero, DoesNotExist
+using ChainRules: ChainRules, rrule, unthunk, AbstractZero, Zero, DoesNotExist, Composite
 using IRTools
 using MacroTools, Requires
 using MacroTools: @forward

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -5,7 +5,7 @@ using LinearAlgebra: copytri!, AbstractTriangular
 using ArrayLayouts: MemoryLayout, AbstractColumnMajor
 
 import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback, literal_getproperty
-using ZygoteRules: differential2legacy, legacy2differential, legacytype_warn, diffgradtuple1
+using ZygoteRules: ZygoteRules, differential2legacy, legacy2differential, legacytype_warn, diffgradtuple1
 
 using ChainRules: ChainRules, rrule, unthunk, AbstractZero, Zero, DoesNotExist, Composite
 using IRTools

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -43,15 +43,15 @@ Convert `x` from the differentials types ChainRules uses to the format Zygote us
 # Zygote convention: even if many AbstractZero partials (i.e. multi-input function), make just 1 nothing.
 @inline wrap_chainrules_output(x::Tuple{Vararg{ChainRules.AbstractZero}}) = Zero()
 @inline wrap_chainrules_output(x::ChainRules.AbstractZero) = x
-for T_outer in (:Tuple, :NamedTuple)
-  # we create separate methods rather than using a `Union` + an `if` so that we avoid a
-  # branch that changes output type, because nested AD on that kinda thing makes Zygote less
-  # than happy.
-  @eval @inline function wrap_chainrules_output(x::ChainRules.Composite{P, T}) where {P, T<:$T_outer}
-    xp = map(wrap_chainrules_output, x)
-    convert($T_outer, xp)
-  end
-end
+#for T_outer in (:Tuple, :NamedTuple)
+#  # we create separate methods rather than using a `Union` + an `if` so that we avoid a
+#  # branch that changes output type, because nested AD on that kinda thing makes Zygote less
+#  # than happy.
+#  @eval @inline function wrap_chainrules_output(x::ChainRules.Composite{P, T}) where {P, T<:$T_outer}
+#    xp = map(wrap_chainrules_output, x)
+#    convert($T_outer, xp)
+#  end
+#end
 
 """
     wrap_chainrules_input(x)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -43,6 +43,7 @@ Convert `x` from the differentials types ChainRules uses to the format Zygote us
 # Zygote convention: even if many AbstractZero partials (i.e. multi-input function), make just 1 nothing.
 @inline wrap_chainrules_output(x::Tuple{Vararg{ChainRules.AbstractZero}}) = Zero()
 @inline wrap_chainrules_output(x::ChainRules.AbstractZero) = x
+#=
 for T_outer in (:Tuple, :NamedTuple)
   # we create separate methods rather than using a `Union` + an `if` so that we avoid a
   # branch that changes output type, because nested AD on that kinda thing makes Zygote less
@@ -52,6 +53,7 @@ for T_outer in (:Tuple, :NamedTuple)
     convert($T_outer, xp)
   end
 end
+=#
 
 """
     wrap_chainrules_input(x)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -61,8 +61,9 @@ end
 Convert `x` from the format Zygote uses internally to differentials types ChainRules uses.
 """
 @inline wrap_chainrules_input(x) = x
-@inline wrap_chainrules_input(::Nothing) = ChainRules.Zero()
+@inline wrap_chainrules_input(::Nothing) = (legacytype_warn(Nothing); return ChainRules.Zero())
 @inline function wrap_chainrules_input(xs::Union{Tuple, NamedTuple})
+  legacytype_warn(typeof(xs))
   xp = map(wrap_chainrules_input, xs)
   ChainRules.Composite{Any, typeof(xp)}(xp)
 end

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -79,7 +79,7 @@ end
 @inline (s::ZBack)(dy) = wrap_chainrules_output(s.back(wrap_chainrules_input(dy)))
 # `nothing->nothing` can be deleted after https://github.com/FluxML/Zygote.jl/issues/603
 # though it might be worth keeping as a performance optimization (benchmarking pending)
-@inline (s::ZBack)(::Nothing) = (legacytype_warn(); return Zero())
+@inline (s::ZBack)(::Nothing) = (legacytype_warn(Nothing); return Zero())
 
 """
     chain_rrule(f, args...)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -41,8 +41,8 @@ tailmemaybe(::Nothing) = nothing
 tailmemaybe(x::Tuple) = Base.tail(x)
 
 function pullback(f, args...)
-  y, back = _pullback(f, args...)
-  y, Δ -> tailmemaybe(differential2legacy(back(legacy2differential(Δ))))
+  y, _back = _pullback(f, args...)
+  y, Δ -> tailmemaybe(differential2legacy(_back(legacy2differential(Δ, typeof(y)))))
 end
 
 sensitivity(y::Number) = one(y)
@@ -169,12 +169,12 @@ end
 
 function pullback(f, ps::Params)
   cx = Context()
-  y, back = _pullback(cx, f)
+  y, _back = _pullback(cx, f)
   y, function (Δ)
     for p in ps
       cache(cx)[p] = nothing
     end
-    differential2legacy(back(legacy2differential(Δ))) # has non-local effects via accum (?)
+    differential2legacy(_back(legacy2differential(Δ, typeof(y)))) # has non-local effects via accum (?)
     Grads(cx.cache, ps) # TODO make a copy
   end
 end

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -42,7 +42,7 @@ tailmemaybe(x::Tuple) = Base.tail(x)
 
 function pullback(f, args...)
   y, _back = _pullback(f, args...)
-  y, Δ -> tailmemaybe(differential2legacy(_back(legacy2differential(Δ, typeof(y)))))
+  y, Δ -> tailmemaybe(differential2legacy(_back(ZygoteRules.l2d(Δ, typeof(y)))))
 end
 
 sensitivity(y::Number) = one(y)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -42,7 +42,7 @@ tailmemaybe(x::Tuple) = Base.tail(x)
 
 function pullback(f, args...)
   y, _back = _pullback(f, args...)
-  y, Δ -> tailmemaybe(differential2legacy(_back(ZygoteRules.l2d(Δ, typeof(y)))))
+  y, Δ -> tailmemaybe(differential2legacy(_back(ZygoteRules.l2d(Δ, y))))
 end
 
 sensitivity(y::Number) = one(y)
@@ -174,7 +174,7 @@ function pullback(f, ps::Params)
     for p in ps
       cache(cx)[p] = nothing
     end
-    differential2legacy(_back(legacy2differential(Δ, typeof(y)))) # has non-local effects via accum (?)
+    differential2legacy(_back(legacy2differential(Δ, y))) # has non-local effects via accum (?)
     Grads(cx.cache, ps) # TODO make a copy
   end
 end

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -45,6 +45,25 @@ function pullback(f, args...)
   y, Δ -> tailmemaybe(differential2legacy(_back(ZygoteRules.l2d(Δ, y))))
 end
 
+#==
+function _pullback(__context__::AContext, ::typeof(pullback), f, args...)
+  lesser_y, _lesser_back = _pullback(__context__, f, args...)
+  lesser_back = Δ -> tailmemaybe(differential2legacy(_lesser_back(ZygoteRules.l2d(Δ, lesser_y))))
+  @show f
+  greater_y = lesser_y, lesser_back
+  @show 2
+  function greater_back(greater_Δ)
+    @show 3
+    Δlesser_y, Δlesser_back = greater_Δ
+    greater_y_again, second_back = _pullback(__context__, _lesser_back, Δlesser_y)
+    Δf_and_Δargs = second_back(greater_Δ)
+    Δf, Δargs = Iterators.peel(Δf_and_Δargs)
+    (Zero(), Δf, Δargs...)
+  end
+  return greater_y, greater_back
+end
+==#
+
 sensitivity(y::Number) = one(y)
 sensitivity(y::Complex) = error("Output is complex, so the gradient is not defined.")
 sensitivity(y) = error("Output should be scalar; gradients are not defined for output $(repr(y))")
@@ -174,7 +193,7 @@ function pullback(f, ps::Params)
     for p in ps
       cache(cx)[p] = nothing
     end
-    differential2legacy(_back(legacy2differential(Δ, y))) # has non-local effects via accum (?)
+    differential2legacy(_back(ZygoteRules.l2d(Δ, y))) # has non-local effects via accum (?)
     Grads(cx.cache, ps) # TODO make a copy
   end
 end

--- a/src/compiler/interface2.jl
+++ b/src/compiler/interface2.jl
@@ -42,7 +42,7 @@ end
   end
   if g == nothing  # No IR found
     Δ <: AbstractZero && return :(Δ)
-    Δ == Nothing && (legacytype_warn(); return :(DoesNotExist()))
+    Δ == Nothing && (legacytype_warn(Nothing); return :(DoesNotExist()))
     return :(error("Non-differentiable function $(repr(j.t[1]))"))
   end
   meta, _, back = g

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -14,7 +14,7 @@ iscall(x, m::Module, n::Symbol) = isexpr(x, :call) && x.args[1] == GlobalRef(m, 
 gradindex(x, i) = x[i]
 gradindex(::Nothing, i) = (legacytype_warn(); return DoesNotExist())
 gradindex(x::AbstractZero, i) = x
-#gradindex(x::Composite, i) = x[i-1] # TODO: what is going on here?
+#gradindex(x::Tuple, i) = 
 xgetindex(x, i...) = xcall(Base, :getindex, x, i...)
 xgradindex(x, i) = xcall(Zygote, :gradindex, x, i)
 
@@ -238,12 +238,10 @@ function adjoint(pr::Primal)
     for v in reverse(keys(b))
       ex = b[v].expr
       if haskey(pr.pullbacks, v)
-        g = push!(rb, stmt(Expr(:call, alpha(pr.pullbacks[v]), grad(v)),
-                           line = b[v].line))
+        g = push!(rb, stmt(Expr(:call, alpha(pr.pullbacks[v]), grad(v)), line = b[v].line))
         for (i, x) in enumerate(ex.args)
           x isa Variable || continue
-          grad(x, push!(rb, stmt(xgradindex(g, i),
-                                 line = b[v].line)))
+          grad(x, push!(rb, stmt(xgradindex(g, i), line = b[v].line)))
         end
       elseif ex isa Core.PiNode
         grads[ex.val] = grads[v]

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -14,6 +14,7 @@ iscall(x, m::Module, n::Symbol) = isexpr(x, :call) && x.args[1] == GlobalRef(m, 
 gradindex(x, i) = x[i]
 gradindex(::Nothing, i) = DoesNotExist()
 gradindex(x::AbstractZero, i) = x
+#gradindex(x::Composite, i) = x[i-1] # TODO: what is going on here?
 xgetindex(x, i...) = xcall(Base, :getindex, x, i...)
 xgradindex(x, i) = xcall(Zygote, :gradindex, x, i)
 

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -12,7 +12,7 @@ using IRTools: IR, Variable, Pipe, xcall, var, prewalk, postwalk,
 iscall(x, m::Module, n::Symbol) = isexpr(x, :call) && x.args[1] == GlobalRef(m, n)
 
 gradindex(x, i) = x[i]
-gradindex(::Nothing, i) = (legacytype_warn(); return DoesNotExist())
+gradindex(::Nothing, i) = (legacytype_warn(Nothing); return DoesNotExist())
 gradindex(x::AbstractZero, i) = x
 xgetindex(x, i...) = xcall(Base, :getindex, x, i...)
 xgradindex(x, i) = xcall(Zygote, :gradindex, x, i)

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -14,7 +14,6 @@ iscall(x, m::Module, n::Symbol) = isexpr(x, :call) && x.args[1] == GlobalRef(m, 
 gradindex(x, i) = x[i]
 gradindex(::Nothing, i) = (legacytype_warn(); return DoesNotExist())
 gradindex(x::AbstractZero, i) = x
-#gradindex(x::Tuple, i) = 
 xgetindex(x, i...) = xcall(Base, :getindex, x, i...)
 xgradindex(x, i) = xcall(Zygote, :gradindex, x, i)
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -204,7 +204,7 @@ function _pullback(cx::AContext, ::typeof(collect), g::Base.Generator)
   y, back = ∇map(cx, g.f, g.iter)
   y, function (ȳ)
     f̄, x̄ = legacy2differential(back(differential2legacy(ȳ)))
-    (DoesNotExist(), (f = f̄, iter = x̄),)
+    (DoesNotExist(), Composite{Any}(f = f̄, iter = x̄),)
   end
 end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -10,7 +10,7 @@ using Distributed: pmap
 
 @nograd ones, zeros, Base.OneTo, Colon(), one, zero
 
-@adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,) # TODO: need to find a way to deal with arrays in legacy2differential
+@adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)
 
 # function _pullback(__context__::AContext, ::typeof(Base.vect), xs...)
 #   _back(::Union{Nothing,AbstractZero}) = Zero()

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -755,7 +755,7 @@ end
     return ((uplo=nothing, info=nothing, factors=nothing),)
   end
 end
-@adjoint function literal_getproperty(C::Cholesky, ::Val{:info})
+@adjoint function literal_getproperty(C::Cholesky, ::Val{:info}) # TODO make sure these work by changing the @adjoint macro
   return literal_getproperty(C, Val(:info)), function(Δ)
     return ((uplo=nothing, info=nothing, factors=nothing),)
   end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -10,7 +10,13 @@ using Distributed: pmap
 
 @nograd ones, zeros, Base.OneTo, Colon(), one, zero
 
-@adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)
+@adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,) # TODO: need to find a way to deal with arrays in legacy2differential
+
+# function _pullback(__context__::AContext, ::typeof(Base.vect), xs...)
+#   _back(::Union{Nothing,AbstractZero}) = Zero()
+#   _back(Δ) = (DoesNotExist(), Δ...)
+#   return Base.vect(xs...), _back
+# end
 
 @adjoint copy(x::AbstractArray) = copy(x), ȳ -> (ȳ,)
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -465,7 +465,7 @@ end
   Y, back = Zygote.pullback((U, B)->U \ (U' \ B), A.U, B)
   return Y, function(Ȳ)
     Ā_factors, B̄ = back(Ȳ)
-    return ((uplo=nothing, status=nothing, factors=Ā_factors), B̄)
+    return ((factors=Ā_factors, uplo=nothing, info=nothing), B̄)
   end
 end
 
@@ -522,7 +522,7 @@ end
   C = cholesky(Σ, check = check)
   return C, Δ::NamedTuple -> begin
     issuccess(C) || throw(PosDefException(C.info))
-    return Diagonal(diag(Δ.factors) .* inv.(2 .* C.factors.diag)), nothing
+    return (Diagonal(diag(Δ.factors) .* inv.(2 .* C.factors.diag)),)
   end
 end
 
@@ -761,30 +761,30 @@ end
 # Various sensitivities for `literal_getproperty`, depending on the 2nd argument.
 @adjoint function literal_getproperty(C::Cholesky, ::Val{:uplo})
   return literal_getproperty(C, Val(:uplo)), function(Δ)
-    return ((uplo=nothing, info=nothing, factors=nothing),)
+    return ((factors=nothing, uplo=nothing, info=nothing), nothing)
   end
 end
 @adjoint function literal_getproperty(C::Cholesky, ::Val{:info}) # TODO make sure these work by changing the @adjoint macro
   return literal_getproperty(C, Val(:info)), function(Δ)
-    return ((uplo=nothing, info=nothing, factors=nothing),)
+    return ((factors=nothing, uplo=nothing, info=nothing), nothing)
   end
 end
 @adjoint function literal_getproperty(C::Cholesky, ::Val{:U})
   return literal_getproperty(C, Val(:U)), function(Δ)
     Δ_factors = C.uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(copy(Δ'))
-    return ((uplo=nothing, info=nothing, factors=Δ_factors),)
+    return ((factors=Δ_factors, uplo=nothing, info=nothing), nothing)
   end
 end
 @adjoint function literal_getproperty(C::Cholesky, ::Val{:L})
   return literal_getproperty(C, Val(:L)), function(Δ)
     Δ_factors = C.uplo == 'L' ? LowerTriangular(Δ) : UpperTriangular(copy(Δ'))
-    return ((uplo=nothing, info=nothing, factors=Δ_factors),)
+    return ((factors=Δ_factors, uplo=nothing, info=nothing), nothing)
   end
 end
 
 @adjoint function logdet(C::Cholesky)
   return logdet(C), function(Δ)
-    return ((uplo=nothing, info=nothing, factors=Diagonal(2 .* Δ ./ diag(C.factors))),)
+    return ((factors=Diagonal(2 .* Δ ./ diag(C.factors)), uplo=nothing, info=nothing),)
   end
 end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -166,10 +166,13 @@ end
 
 # if we have an iterator, unzip may (will) lose track of what the outer type should be
 # First arg is the primal iterator type to reconstruct to
-reconstruct_differential_from_iterator(::Type{T}, diff_iter::T) where T = diff_iter
+reconstruct_differential_from_iterator(::Type{T}, diff_iter) where T<:Union{UnitRange, StepRange} = diff_iter
 reconstruct_differential_from_iterator(::Type{T}, diff_iter) where T<:AbstractArray = convert(T, diff_iter)
 reconstruct_differential_from_iterator(::Type{T}, diff_iter) where T<:Tuple = Composite{T}(diff_iter...)
-reconstruct_differential_from_iterator(::Type{T}, diff_iter) where T<:NamedTuple = Composite{T}(; diff_iter...)
+reconstruct_differential_from_iterator(::Type{T}, diff_iter) where T<:NamedTuple = Composite{T}(;NamedTuple{fieldnames(T)}(diff_iter)...)
+
+# TODO: piracy, move to ChainRulesCore.jl
+Base.convert(::Type{T}, x::AbstractZero) where T <: Real = zero(T)
 
 # Reverse iteration order when ∇map is applied to vector,
 # needed for stateful functions.

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -204,7 +204,7 @@ function _pullback(cx::AContext, ::typeof(collect), g::Base.Generator)
   y, back = ∇map(cx, g.f, g.iter)
   y, function (ȳ)
     f̄, x̄ = legacy2differential(back(differential2legacy(ȳ)))
-    (DoesNotExist(), Composite{Any}(f = f̄, iter = x̄),)
+    (DoesNotExist(), Composite{typeof(g)}(f = f̄, iter = x̄),)
   end
 end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -12,12 +12,6 @@ using Distributed: pmap
 
 @adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)
 
-# function _pullback(__context__::AContext, ::typeof(Base.vect), xs...)
-#   _back(::Union{Nothing,AbstractZero}) = Zero()
-#   _back(Δ) = (DoesNotExist(), Δ...)
-#   return Base.vect(xs...), _back
-# end
-
 @adjoint copy(x::AbstractArray) = copy(x), ȳ -> (ȳ,)
 
 @adjoint collect(x::Tuple) = collect(x), dy -> (Tuple(dy),)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -203,8 +203,9 @@ for (mapfunc,∇mapfunc) in [(:map,:∇map),(:pmap,:∇pmap),(:vmap,:∇vmap)]
 
   @eval function _pullback(__context__::AContext, ::typeof($mapfunc), f, args::Union{AbstractArray,Tuple}...)
     ys, _f_back = $∇mapfunc(__context__, f, args...)
-    _back(::Union{Nothing,AbstractZero}) = Zero()
-    _back(Δ) = gradtuple1(_f_back(Δ))
+    _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+    _back(x::AbstractZero) = x
+    _back(Δ) = diffgradtuple1(_f_back(Δ))
     return ys, _back
   end
 end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -182,8 +182,12 @@ _tryreverse(m, backs, Δ) = backs, Δ
 function _tryreverse(m::typeof(map), backs, Δ::Union{AbstractVector, Tuple})
   return reverse(backs), reverse(Δ)
 end
+function _tryreverse(m::typeof(map), backs, Δ::Composite)
+  return reverse(backs), _tryreverse(m, Δ)
+end
 _tryreverse(m, x) = x
 _tryreverse(m::typeof(map), x::Union{AbstractVector, Tuple}) = reverse(x)
+_tryreverse(m::typeof(map), c::Composite) = Composite{typeof(reverse(c.backing)), typeof(reverse(c.backing))}(reverse(c.backing))
 
 for (mapfunc,∇mapfunc) in [(:map,:∇map),(:pmap,:∇pmap),(:vmap,:∇vmap)]
   @eval function $∇mapfunc(cx, f, args...)

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -68,10 +68,10 @@ function _pullback(__context__::AContext, ::Type{<:Task}, f)
   t = Task(f)
   t.code = function ()
     y, _back = _pullback(__context__, f)
-    cache(__context__)[t] = Task(_back)
+    cache(__context__)[t] = Task(_back)  # when `fetch`ed, this returns a tuple: (f̄,)
     return y
   end
-  return t, _ -> (DoesNotExist(), fetch(cache(__context__)[t]))
+  return t, _ -> (DoesNotExist(), first(fetch(cache(__context__)[t])))
 end
 
 function runadjoint(cx, t, ȳ = DoesNotExist())

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -177,7 +177,7 @@ end
 
 @adjoint! function (b::typeof(broadcast))(f, args...)
   y, _back = _pullback(__context__, broadcasted, f, args...)
-  y, Δ -> differential2legacy(_back(legacy2differential(Δ, typeof(y))))
+  y, Δ -> differential2legacy(_back(legacy2differential(Δ, y)))
 end
 
 # Forward Mode (mainly necessary for CUDA)

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -278,8 +278,8 @@ const allowed_gradient_T = Union{
     Nothing,
     AbstractZero,
     RefValue,
-    ChainRules.Composite{Any, T} where T<:Union{Tuple, NamedTuple}
-    }
+    ChainRules.Composite{Any, T} where T<:Union{Tuple, NamedTuple} # TODO implement in the functions
+}
 
 # TODO captured mutables + multiple calls to `back`
 @generated function (back::Jnew{T,G,false})(Δ::allowed_gradient_T) where {T,G}

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -271,7 +271,7 @@ end
 
 # TODO captured mutables + multiple calls to `back`
 @generated function (back::Jnew{T,G,false})(Δ::Union{NamedTuple,Nothing,AbstractZero,RefValue}) where {T,G}
-  Δ == Nothing && legacytype_warn()
+  Δ <: Union{Nothing, NamedTuple} && legacytype_warn()
   if !T.mutable
     Δ <: AbstractZero && return :Δ
   end
@@ -290,6 +290,7 @@ end
 end
 
 @generated function (back::Jnew{T,G,true})(Δ::Union{NamedTuple,Nothing,AbstractZero,RefValue}) where {T,G}
+  Δ <: Union{Nothing, NamedTuple} && legacytype_warn()
   !T.mutable && Δ <: AbstractZero && return :Δ
   if G <: AbstractZero
     quote

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -230,7 +230,8 @@ _pullback(cx::Context, ::typeof(literal_getindex), x::NamedTuple, ::Val{f}) wher
 _pullback(cx::Context, ::typeof(literal_getproperty), x::Tuple, ::Val{f}) where f =
   _pullback(cx, literal_getindex, x, Val(f))
 
-grad_mut(x) = Ref{Any}(nt_zero(x))
+#grad_mut(x) = Ref{Any}(nt_zero(x)) # TODO
+grad_mut(x::T) where T = Ref{Any}(Composite{T}())
 
 function grad_mut(cx::Context, x)
   ch = cache(cx)
@@ -274,7 +275,7 @@ const allowed_gradient_T = Union{
   Nothing,
   AbstractZero,
   RefValue,
-  ChainRules.Composite{Any, T} where T<:Union{Tuple, NamedTuple}
+  ChainRules.Composite#{Any, T} where T<:Union{Tuple, NamedTuple} #TODO
 }
 
 # TODO captured mutables + multiple calls to `back`

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -176,7 +176,7 @@ function _pullback(__context__::AContext, ::typeof(Core._apply), f, args...)
     if Δ isa AbstractZero
       return Δ
     else
-      gradtuple1((first(Δ), unapply(st, Base.tail(Δ))...))
+      return (DoesNotExist(), first(Δ), unapply(st, Base.tail(Δ))...)
     end
   end
 end
@@ -190,7 +190,7 @@ if VERSION >= v"1.4.0-DEV.304"
       if Δ isa AbstractZero
         return Δ
       else
-        gradtuple1((DoesNotExist(), first(Δ), unapply(st, Base.tail(Δ))...))
+        return (DoesNotExist(), DoesNotExist(), first(Δ), unapply(st, Base.tail(Δ))...)
       end
     end
   end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -294,7 +294,7 @@ const allowed_gradient_T = Union{
   quote
     x̄ = $Δ_expr
     $(G <: AbstractZero || :(back.g[] = nt_zero($Δ_expr)))
-    return (DoesNotExist(), $(map(f -> :(x̄.$f), fieldnames(T))...))
+    (DoesNotExist(), Composite{Any}($(map(f -> :(x̄.$f), fieldnames(T))...)))
   end
 end
 
@@ -306,13 +306,13 @@ end
   end
   if G <: AbstractZero
     quote
-      (DoesNotExist(), ($(map(f -> :(Δ.$f), fieldnames(T))...),))
+      (DoesNotExist(), Composite{Any}($(map(f -> :(Δ.$f), fieldnames(T))...),))
     end
   else # TODO is this dead code? back is an (immutable) struct
     quote
       x̄ = back.g
       back.g = nt_zero(back.g)
-      (DoesNotExist(), ($(map(f -> :(x̄.$f), fieldnames(T))...),))
+      (DoesNotExist(), Composite{Any}($(map(f -> :(x̄.$f), fieldnames(T))...),))
     end
   end
 end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -251,7 +251,7 @@ end
   end
 end
 
-struct Jnew{T,G,splat}
+struct Jnew{T,G,splat} # T is the primal type, G is the gradient type
   g::G
 end
 

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -179,7 +179,10 @@ function _pullback(__context__::AContext, ::typeof(Core._apply), f, args...)
       return Δ
     else
       tuple_grads = unapply(st, Base.tail(Δ))
-      composite_grads = ((Composite{typeof(tg), typeof(tg)}(tg) for tg in tuple_grads)...,)
+      composite_grads = ntuple(
+        i -> Composite{typeof(tuple_grads[i]), typeof(tuple_grads[i])}(tuple_grads[i]),
+        length(tuple_grads)
+      )
       return (DoesNotExist(), first(Δ), composite_grads...)
     end
   end
@@ -195,7 +198,10 @@ if VERSION >= v"1.4.0-DEV.304"
         return Δ
       else
         tuple_grads = unapply(st, Base.tail(Δ))
-        composite_grads = ((Composite{typeof(tg), typeof(tg)}(tg) for tg in tuple_grads)...,)
+        composite_grads = ntuple(
+          i -> Composite{typeof(tuple_grads[i]), typeof(tuple_grads[i])}(tuple_grads[i]),
+          length(tuple_grads)
+        )
         return (DoesNotExist(), DoesNotExist(), first(Δ), composite_grads...)
       end
     end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -269,14 +269,6 @@ function _pullback(__context__::AContext, ::typeof(__splatnew__), ::Type{T}, arg
   return x,  Δ -> ZygoteRules.gradtuple1(Jnew{T,typeof(g),true}(g)(Δ))
 end
 
-const allowed_gradient_T = Union{
-    NamedTuple,
-    Nothing,
-    AbstractZero,
-    RefValue,
-    ChainRules.Composite{Any, T} where T<:Union{Tuple, NamedTuple} # TODO implement in the functions
-}
-
 # TODO captured mutables + multiple calls to `back`
 @generated function (back::Jnew{T,G,false})(Δ::Union{NamedTuple,Nothing,AbstractZero,RefValue}) where {T,G}
   Δ == Nothing && legacytype_warn()

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -178,7 +178,9 @@ function _pullback(__context__::AContext, ::typeof(Core._apply), f, args...)
     if Δ isa AbstractZero
       return Δ
     else
-      return (DoesNotExist(), first(Δ), unapply(st, Base.tail(Δ))...)
+      tuple_grads = unapply(st, Base.tail(Δ))
+      composite_grads = ((Composite{typeof(tg), typeof(tg)}(tg) for tg in tuple_grads)...,)
+      return (DoesNotExist(), first(Δ), composite_grads...)
     end
   end
 end
@@ -192,7 +194,9 @@ if VERSION >= v"1.4.0-DEV.304"
       if Δ isa AbstractZero
         return Δ
       else
-        return (DoesNotExist(), DoesNotExist(), first(Δ), unapply(st, Base.tail(Δ))...)
+        tuple_grads = unapply(st, Base.tail(Δ))
+        composite_grads = ((Composite{typeof(tg), typeof(tg)}(tg) for tg in tuple_grads)...,)
+        return (DoesNotExist(), DoesNotExist(), first(Δ), composite_grads...)
       end
     end
   end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -111,7 +111,7 @@ end
 
 function _pullback(cx::Context, ::typeof(literal_indexed_iterate), xs::Tuple, ::Val{i}) where i
   y, b = _pullback(cx, literal_getindex, xs, Val(i))
-  back(::Nothing) = (legacytype_warn(); return Zero())
+  back(::Nothing) = (legacytype_warn(Nothing); return Zero())
   back(x::AbstractZero) = x
   back(ȳ) = b(ȳ[1])
   (y, i+1), back
@@ -119,7 +119,7 @@ end
 
 function _pullback(cx::Context, ::typeof(literal_indexed_iterate), xs::Tuple, ::Val{i}, st) where i
   y, b = _pullback(cx, literal_getindex, xs, Val(i))
-  back(::Nothing) = (legacytype_warn(); return Zero())
+  back(::Nothing) = (legacytype_warn(Nothing); return Zero())
   back(x::AbstractZero) = x
   back(ȳ) = (b(ȳ[1])..., Zero())
   (y, i+1), back
@@ -279,7 +279,7 @@ const allowed_gradient_T = Union{
 
 # TODO captured mutables + multiple calls to `back`
 @generated function (back::Jnew{T,G,false})(Δ::allowed_gradient_T) where {T,G}
-  Δ <: Union{Nothing, NamedTuple} && legacytype_warn()
+  Δ <: Union{Nothing, NamedTuple} && legacytype_warn(Δ)
   if !T.mutable
     Δ <: AbstractZero && return :Δ
   end
@@ -293,12 +293,12 @@ const allowed_gradient_T = Union{
   quote
     x̄ = $Δ_expr
     $(G <: AbstractZero || :(back.g[] = nt_zero($Δ_expr)))
-    return (DoesNotExist(), ($(map(fn -> :(x̄.$fn), fieldnames(T))...)))
+    return (DoesNotExist(), $(map(fn -> :(x̄.$fn), fieldnames(T))...))
   end
 end
 
 @generated function (back::Jnew{T,G,true})(Δ::allowed_gradient_T) where {T,G}
-  Δ == Union{Nothing, NamedTuple} && legacytype_warn()
+  Δ == Union{Nothing, NamedTuple} && legacytype_warn(Δ)
   if !T.mutable
     Δ <: AbstractZero && return :Δ
   end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -224,7 +224,8 @@ end
 
 function _pullback(__context__::AContext, ::typeof(literal_getproperty), x, ::Val{f}) where f
     val = getproperty(x, f)
-    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+    _back(x::AbstractZero) = x
     function _back(Δ)
       accum_param(__context__, val, Δ) isa AbstractZero && return Zero()
       if isimmutable(x)

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -18,8 +18,6 @@ end
 
 # Complex Numbers
 
-@adjoint (T::Type{<:Complex})(re, im) = T(re, im), c̄ -> (nothing, real(c̄), imag(c̄))
-
 # we define these here because ChainRules.jl only defines them for x::Union{Real,Complex}
 
 @adjoint abs2(x::Number) = abs2(x), Δ -> (real(Δ)*(x + x),)

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -8,7 +8,8 @@
 @adjoint Base.convert(T::Type{<:Real}, x::Real) = convert(T, x), ȳ -> (nothing, ȳ)
 
 function _pullback(__context__::AContext, ::Type{T}, x::Real) where T<:Real
-  _back(::Union{Nothing,AbstractZero}) = Zero()
+  _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+  _back(x::AbstractZero) = x
   # Nonsense follows:
   # extra DoesNotExist at the start because this is a `:new` not a `:call`
   _back(Δ) = (DoesNotExist(), DoesNotExist(), Δ)

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -6,7 +6,14 @@
   Δ -> (nothing, Δ * conj(p * Base.literal_pow(^,x,Val(p-1))), nothing)
 
 @adjoint Base.convert(T::Type{<:Real}, x::Real) = convert(T, x), ȳ -> (nothing, ȳ)
-@adjoint (T::Type{<:Real})(x::Real) = T(x), ȳ -> (nothing, ȳ)
+
+function _pullback(__context__::AContext, ::Type{T}, x::Real) where T<:Real
+  _back(::Union{Nothing,AbstractZero}) = Zero()
+  # Nonsense follows:
+  # extra DoesNotExist at the start because this is a `:new` not a `:call`
+  _back(Δ) = (DoesNotExist(), DoesNotExist(), Δ)
+  return T(x), _back
+end
 
 for T in Base.uniontypes(Core.BuiltinInts)
     @adjoint (::Type{T})(x::Core.BuiltinInts) = T(x), Δ -> (Δ,)

--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -11,7 +11,7 @@ end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(xlogx), x::Numeric)
     result, dx = ∇xlogx(x)
     _back(::Union{Nothing,AbstractZero}) = Zero()
-    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx)))
+    _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx))
     return result, _back
 end
 function ∇xlogx(x::Numeric)
@@ -38,7 +38,7 @@ end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(log1pexp), x::Numeric)
     dx = ∂log1pexp.(x)
     _back(::Union{Nothing,AbstractZero}) = Zero()
-    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx)))
+    _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx))
     return log1pexp.(x), _back
 end
 ∂log1pexp(x::Real)    = x < 18.0 ? logistic(x) : x < 33.3 ? one(x) - exp(-x) : oftype(exp(x), 1)
@@ -57,7 +57,7 @@ end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(xlogy), x::Numeric, y::Numeric)
     result, dx, dy = ∇xlogy(x, y)
     _back(::Union{Nothing,AbstractZero}) = Zero()
-    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy)))
+    _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy))
     return result, _back
 end
 function ∇xlogy(x::Numeric, y::Numeric)
@@ -76,7 +76,7 @@ end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(logaddexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logaddexp(x, y)
     _back(::Union{Nothing,AbstractZero}) = Zero()
-    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy)))
+    _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy))
     return result, _back
 end
 function ∇logaddexp(x::Numeric, y::Numeric)
@@ -94,7 +94,7 @@ end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(logsubexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logsubexp(x, y)
     _back(::Union{Nothing,AbstractZero}) = Zero()
-    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy)))
+    _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy))
     return result, _back
 end
 function ∇logsubexp(x::Numeric, y::Numeric)

--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -10,7 +10,8 @@ using Base.Broadcast: broadcasted
 end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(xlogx), x::Numeric)
     result, dx = ∇xlogx(x)
-    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+    _back(x::AbstractZero) = x
     _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx))
     return result, _back
 end
@@ -37,7 +38,8 @@ end
 end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(log1pexp), x::Numeric)
     dx = ∂log1pexp.(x)
-    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+    _back(x::AbstractZero) = x
     _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx))
     return log1pexp.(x), _back
 end
@@ -56,7 +58,8 @@ end
 end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(xlogy), x::Numeric, y::Numeric)
     result, dx, dy = ∇xlogy(x, y)
-    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+    _back(x::AbstractZero) = x
     _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy))
     return result, _back
 end
@@ -75,7 +78,8 @@ end
 end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(logaddexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logaddexp(x, y)
-    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+    _back(x::AbstractZero) = x
     _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy))
     return result, _back
 end
@@ -93,7 +97,8 @@ end
 end
 function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(logsubexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logsubexp(x, y)
-    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(::Nothing) = (legacytype_warn(Nothing); return Zero())
+    _back(x::AbstractZero) = x
     _back(Δ) = (DoesNotExist(), DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy))
     return result, _back
 end

--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -8,10 +8,11 @@ using Base.Broadcast: broadcasted
     back(δ) = (dx * δ,)
     return result, back
 end
-@adjoint function broadcasted(::typeof(xlogx), x::Numeric)
+function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(xlogx), x::Numeric)
     result, dx = ∇xlogx(x)
-    back(δ) = (nothing, unbroadcast(x, δ .* dx))
-    return result, back
+    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx)))
+    return result, _back
 end
 function ∇xlogx(x::Numeric)
     logx = log.(x)
@@ -34,9 +35,11 @@ end
     dx = ∂log1pexp(x)
     return log1pexp(x), δ -> (δ * dx,)
 end
-@adjoint function broadcasted(::typeof(log1pexp), x::Numeric)
+function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(log1pexp), x::Numeric)
     dx = ∂log1pexp.(x)
-    return log1pexp.(x), δ -> (nothing, unbroadcast(x, δ .* dx))
+    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx)))
+    return log1pexp.(x), _back
 end
 ∂log1pexp(x::Real)    = x < 18.0 ? logistic(x) : x < 33.3 ? one(x) - exp(-x) : oftype(exp(x), 1)
 ∂log1pexp(x::Float32) = x < 9f0  ? logistic(x) : x < 16f0 ? one(x) - exp(-x) : oftype(exp(x), 1)
@@ -51,10 +54,11 @@ end
     back(δ) = (δ * dx, δ * dy)
     return result, back
 end
-@adjoint function broadcasted(::typeof(xlogy), x::Numeric, y::Numeric)
+function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(xlogy), x::Numeric, y::Numeric)
     result, dx, dy = ∇xlogy(x, y)
-    back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
-    return result, back
+    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy)))
+    return result, _back
 end
 function ∇xlogy(x::Numeric, y::Numeric)
     dx = logy = log.(y)
@@ -69,10 +73,11 @@ end
     back(δ) = (δ * dx, δ * dy)
     return result, back
 end
-@adjoint function broadcasted(::typeof(logaddexp), x::Numeric, y::Numeric)
+function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(logaddexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logaddexp(x, y)
-    back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
-    return result, back
+    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy)))
+    return result, _back
 end
 function ∇logaddexp(x::Numeric, y::Numeric)
     result = logaddexp.(x, y)
@@ -86,10 +91,11 @@ end
     back(δ) = (δ * dx, δ * dy)
     return result, back
 end
-@adjoint function broadcasted(::typeof(logsubexp), x::Numeric, y::Numeric)
+function _pullback(__context__::AContext, ::typeof(broadcasted), ::typeof(logsubexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logsubexp(x, y)
-    back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
-    return result, back
+    _back(::Union{Nothing,AbstractZero}) = Zero()
+    _back(Δ) = gradtuple1((DoesNotExist(), unbroadcast(x, Δ .* dx), unbroadcast(y, Δ .* dy)))
+    return result, _back
 end
 function ∇logsubexp(x::Numeric, y::Numeric)
     result = logsubexp.(x, y)

--- a/test/features.jl
+++ b/test/features.jl
@@ -230,12 +230,14 @@ end[1] == 5
   x
 end[1] == 2
 
-# Gradient of closure
-grad_closure(x) = 2x
+# test using call overload form of `@adjoint`
+grad_callover(x) = 2x
 
-Zygote.@adjoint (f::typeof(grad_closure))(x) = f(x), Δ -> (1, 2)
+# Equivelent to:
+# Zygote.@adjoint grad_callover(x) = grad_callover(x), Δ -> (2Δ,)
+Zygote.@adjoint (f::typeof(grad_callover))(x) = f(x), Δ -> (1, 2Δ,) # set the gradient wrong so that it is tested
 
-@test gradient((f, x) -> f(x), grad_closure, 5) == (1, 2)
+@test gradient((f, x) -> f(x), grad_callover, 5) == (1, 2)
 
 invokable(x) = 2x
 invokable(x::Integer) = 3x

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -343,7 +343,7 @@ for mapfunc in [map,pmap,vmap]
     x = randn(3)
     _, pb = Zygote.pullback(x -> map(abs2, x), x)
     Δy = randn(3)
-    @test first(pb((Δy..., ))) ≈ first(pb(Δy))
+    @test length(first(pb(Δy))) == 3
   end
 end
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -345,6 +345,22 @@ for mapfunc in [map,pmap,vmap]
     Δy = randn(3)
     @test length(first(pb(Δy))) == 3
   end
+
+  @testset "_pullback outputs differential type for tuple" begin
+    _, pb = Zygote._pullback(map, identity, (1,1,1))
+    @test pb(Composite{Tuple{Int, Int, Int}}(1,2,3)) ==
+        pb((1, 2, 3)) ==
+        (DoesNotExist(), Zero(), Composite{Tuple{Int64,Int64,Int64}}(1, 2, 3))
+  end
+
+  @testset "_pullback outputs differential type for named tuple" begin
+  _, pb = Zygote._pullback(map, identity, (a=1, b=1, c=1))
+  nt = (a=1, b=2, c=3)
+  cnt = cnt = Composite{typeof(nt), typeof(nt)}(nt)
+  @test pb(nt) ==
+    pb(cnt) ==
+    (Zero(), Zero(), Composite{NamedTuple{(:a, :b, :c),Tuple{Int64,Int64,Int64}}}(a = 1, b = 2, c = 3))
+  end
 end
 
 @testset "Stateful Map" begin


### PR DESCRIPTION
Very basic so far, only removes the wrapping of chain rules output from Composite to NamedTuple.

The main thing is to implement this inside the fallback `_pullback` function doing the source code transformation.

There is a [paired PR in ZygoteRules ](https://github.com/mzgubic/ZygoteRules.jl/pull/1)which deals with changing the `@adjoint` macro to support Composite.